### PR TITLE
Clean warnings

### DIFF
--- a/Source/FTObjects/FTDictionaryClass.f90
+++ b/Source/FTObjects/FTDictionaryClass.f90
@@ -242,8 +242,6 @@
 !
             PROCEDURE :: initWithSize
             PROCEDURE :: init
-!            PROCEDURE :: setCaseSensitive
-!            PROCEDURE :: caseSensitive
             PROCEDURE :: allKeys
             PROCEDURE :: allObjects
             FINAL     :: destructFTDictionary
@@ -326,23 +324,6 @@
             self % entries => NULL()
             
          END SUBROUTINE destructFTDictionary    
-!
-!//////////////////////////////////////////////////////////////////////// 
-! 
-!         SUBROUTINE setCaseSensitive(self,bool)  
-!            IMPLICIT NONE  
-!            CLASS(FTDictionary) :: self
-!            LOGICAL             :: bool
-!            self % isCaseSensitive = bool
-!         END SUBROUTINE setCaseSensitive  
-!
-!//////////////////////////////////////////////////////////////////////// 
-! 
-!         LOGICAL FUNCTION caseSensitive(self)  
-!            IMPLICIT NONE  
-!            CLASS(FTDictionary) :: self
-!            caseSensitive = self % isCaseSensitive
-!         END FUNCTION caseSensitive      
 !
 !//////////////////////////////////////////////////////////////////////// 
 ! 

--- a/Source/FTTesting/Assert.f90
+++ b/Source/FTTesting/Assert.f90
@@ -213,6 +213,7 @@
 !        ------------------------------
 !
          current => self % failureListHead
+         tmp => current % next
          DO WHILE (ASSOCIATED(tmp))
             tmp => current % next
             DEALLOCATE(current)

--- a/Source/FTTesting/TestSuiteManagerClass.f90
+++ b/Source/FTTesting/TestSuiteManagerClass.f90
@@ -214,6 +214,7 @@
          END IF 
          
          current => self % testCasesHead
+         tmp => current % next
          DO WHILE (ASSOCIATED(tmp))
             tmp => current % next
             

--- a/Testing/Tests/ExceptionTests.f90
+++ b/Testing/Tests/ExceptionTests.f90
@@ -45,7 +45,6 @@
             CLASS(FTException)      , POINTER :: testException
             TYPE (FTValueDictionary), POINTER :: userDictionary
             CLASS(FTDictionary)     , POINTER :: ptr
-            CLASS(FTObject)         , POINTER :: obj
             REAL                              :: r = 3.1416
             
             ALLOCATE(userDictionary)
@@ -72,7 +71,6 @@
          IMPLICIT NONE 
          
          TYPE (FTException) , POINTER :: exception
-         CLASS(FTObject)    , POINTER :: obj
          
          exception => testException()
          CALL throw(exception)

--- a/Testing/Tests/StacksTests.f90
+++ b/Testing/Tests/StacksTests.f90
@@ -106,7 +106,7 @@
          IMPLICIT NONE  
          
          TYPE (FTStack) , POINTER :: stack
-         TYPE (FTValue) , POINTER :: r1, r2, r3
+         TYPE (FTValue) , POINTER :: r2, r3
          CLASS(FTObject), POINTER :: objectPtr
 !
 !        ---------------

--- a/Testing/Tests/ValueClassTests.f90
+++ b/Testing/Tests/ValueClassTests.f90
@@ -65,13 +65,12 @@
 !        Some values to convert into FTValue objects
 !        -------------------------------------------
 !
-         REAL                            :: r = 3.14, x
-         REAL(KIND=KIND(1.0d0))          :: d, dd
-         INTEGER                         :: i = 666, j
-         CHARACTER(LEN=:), ALLOCATABLE   :: s
-         DOUBLE PRECISION                :: doubleTol = 2*EPSILON(1.0d0)
-         REAL                            :: singleTol = 2*EPSILON(1.0e0)
-         CLASS(FTObject), POINTER        :: obj
+         REAL                                          :: r = 3.14, x
+         REAL(KIND=KIND(1.0d0))                        :: d, dd
+         INTEGER                                       :: i = 666, j
+         DOUBLE PRECISION                              :: doubleTol = 2*EPSILON(1.0d0)
+         REAL                                          :: singleTol = 2*EPSILON(1.0e0)
+         CHARACTER(LEN=DESCRIPTION_CHARACTER_LENGTH)   :: s
 !
 !        --------------------------------------------
 !        Create an object storing a real value

--- a/Testing/Tests/ValueDictionaryTests.f90
+++ b/Testing/Tests/ValueDictionaryTests.f90
@@ -42,7 +42,6 @@
          IMPLICIT NONE  
          
          TYPE(FTValueDictionary)      :: dict, dict2
-         CLASS(FTDictionary), POINTER :: dictPtr
 !
 !        -----------------------
 !        Example values and keys


### PR DESCRIPTION
Remove issues giving warnings under
-Wall -Wextra -Wno-unused-dummy-argument -std=f2008 -pedantic
Mecessary floating equality warnings remain. Also the count method is the same a a fortran function.