### PR TITLE
Rename `master` to `main` where relevant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'AUTHORS.md'
       - 'LICENSE.md'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags: '*'
     paths-ignore:
       - '.github/workflows/ci.yml'
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: ford Docs/FTObjectLibraryProject.md
       - name: Deploy
-        if: github.ref == 'refs/heads/master' # Only run on master
+        if: github.ref == 'refs/heads/main' # Only run on main
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FTObjectLibrary
 
 [![Build Status](https://github.com/trixi-framework/FTObjectLibrary/workflows/CI/badge.svg)](https://github.com/trixi-framework/FTObjectLibrary/actions?query=workflow%3ACI)
-[![Coveralls](https://coveralls.io/repos/github/trixi-framework/FTObjectLibrary/badge.svg?branch=master)](https://coveralls.io/github/trixi-framework/FTObjectLibrary?branch=master)
-[![Codecov](https://codecov.io/gh/trixi-framework/FTObjectLibrary/branch/master/graph/badge.svg)](https://codecov.io/gh/trixi-framework/FTObjectLibrary)
+[![Coveralls](https://coveralls.io/repos/github/trixi-framework/FTObjectLibrary/badge.svg?branch=main)](https://coveralls.io/github/trixi-framework/FTObjectLibrary?branch=main)
+[![Codecov](https://codecov.io/gh/trixi-framework/FTObjectLibrary/branch/main/graph/badge.svg)](https://codecov.io/gh/trixi-framework/FTObjectLibrary)
 [![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
 
 FTObjectLibrary provides a collection of reference counted Fortran 2003 classes


### PR DESCRIPTION
For the rationale, please refer to https://github.com/trixi-framework/HOHQMesh/pull/15.

**Note: Please do not merge this until the actual name change has been applied to the GitHub repo.**