### PR TITLE
Initialize the temporary FTObject pointer in AddString

### DIFF
--- a/Source/FTObjects/FTStringSetClass.f90
+++ b/Source/FTObjects/FTStringSetClass.f90
@@ -238,6 +238,7 @@
          IF(self % dict % containsKey(key = str))     RETURN 
          
          ALLOCATE(obj)
+         CALL obj % init()
          CALL self % dict % addObjectForKey(object = obj,key = str)
          CALL release(obj)
          


### PR DESCRIPTION
* The use of the allocated but uninitialized FTObject pointer in
  AddString caused random warning statements about FTObject
```
 Attempt to release object with refCount = 0
 FTObject
```
This is also results in warnings from valgrind about conditional
evaluation based on uninitialized data.

This patch initializes the object, even though it is an empty object,
to alleviate this issue.

Related to the discussion on https://github.com/trixi-framework/HOHQMesh/pull/34