### PR TITLE
Update gfortran in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-22.04
+            compiler: gfortran-10
+            cmake_generator: Unix Makefiles
+            shell: bash
           - os: ubuntu-latest
             compiler: gfortran-13
             cmake_generator: Unix Makefiles


### PR DESCRIPTION
Set the gfortran compiler to be `gfortran-12` as `gfortran-10` is no longer available on the latest Ubuntu runners (https://github.com/actions/runner-images/issues/10636).